### PR TITLE
Initialize HearHere iOS project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Xcode
+DerivedData/
+*.xcworkspace
+xcuserdata/
+*.xcuserstate
+
+# Swift Package Manager
+.build/
+.swiftpm/
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/
+
+# Accidental
+.DS_Store
+*.m4a
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/
+fastlane/test_output
+
+# Generated
+*.ipa
+*.dSYM

--- a/HearHere.xcodeproj/project.pbxproj
+++ b/HearHere.xcodeproj/project.pbxproj
@@ -1,0 +1,390 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 55;
+objects = {
+
+/* Begin PBXBuildFile section */
+AAB0C8D029D14E2100000020 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BA29D14E2100000010 /* ContentView.swift */; };
+AAB0C8D129D14E2100000021 /* HearHereApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8B929D14E210000000F /* HearHereApp.swift */; };
+AAB0C8D229D14E2100000022 /* AudioDropViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BB29D14E2100000011 /* AudioDropViewModel.swift */; };
+AAB0C8D329D14E2100000023 /* AudioDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BC29D14E2100000012 /* AudioDrop.swift */; };
+AAB0C8D429D14E2100000024 /* AudioDropStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BD29D14E2100000013 /* AudioDropStore.swift */; };
+AAB0C8D529D14E2100000025 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BE29D14E2100000014 /* AudioRecorder.swift */; };
+AAB0C8D629D14E2100000026 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8BF29D14E2100000015 /* LocationManager.swift */; };
+AAB0C8D729D14E2100000027 /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB0C8C029D14E2100000016 /* AudioPlayer.swift */; };
+AAB0C8D829D14E2100000028 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAB0C8C129D14E2100000017 /* Assets.xcassets */; };
+AAB0C8D929D14E2100000029 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAB0C8C329D14E2100000019 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+AAB0C8B229D14E2100000008 /* HearHere.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HearHere.app; sourceTree = BUILT_PRODUCTS_DIR; };
+AAB0C8B929D14E210000000F /* HearHereApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HearHereApp.swift; sourceTree = "<group>"; };
+AAB0C8BA29D14E2100000010 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+AAB0C8BB29D14E2100000011 /* AudioDropViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDropViewModel.swift; sourceTree = "<group>"; };
+AAB0C8BC29D14E2100000012 /* AudioDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDrop.swift; sourceTree = "<group>"; };
+AAB0C8BD29D14E2100000013 /* AudioDropStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDropStore.swift; sourceTree = "<group>"; };
+AAB0C8BE29D14E2100000014 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
+AAB0C8BF29D14E2100000015 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+AAB0C8C029D14E2100000016 /* AudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
+AAB0C8C129D14E2100000017 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+AAB0C8C229D14E2100000018 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+AAB0C8C329D14E2100000019 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+AAB0C8AF29D14E2100000005 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+AAB0C8AC29D14E2100000002 = {
+isa = PBXGroup;
+children = (
+AAB0C8B329D14E2100000009 /* HearHere */,
+AAB0C8B129D14E2100000007 /* Products */,
+);
+sourceTree = "<group>";
+};
+AAB0C8B129D14E2100000007 /* Products */ = {
+isa = PBXGroup;
+children = (
+AAB0C8B229D14E2100000008 /* HearHere.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+AAB0C8B329D14E2100000009 /* HearHere */ = {
+isa = PBXGroup;
+children = (
+AAB0C8B929D14E210000000F /* HearHereApp.swift */,
+AAB0C8BA29D14E2100000010 /* ContentView.swift */,
+AAB0C8B529D14E210000000B /* Models */,
+AAB0C8B629D14E210000000C /* ViewModels */,
+AAB0C8B429D14E210000000A /* Managers */,
+AAB0C8B729D14E210000000D /* Resources */,
+AAB0C8B829D14E210000000E /* Preview Content */,
+AAB0C8C229D14E2100000018 /* Info.plist */,
+);
+path = HearHere;
+sourceTree = "<group>";
+};
+AAB0C8B429D14E210000000A /* Managers */ = {
+isa = PBXGroup;
+children = (
+AAB0C8BD29D14E2100000013 /* AudioDropStore.swift */,
+AAB0C8BE29D14E2100000014 /* AudioRecorder.swift */,
+AAB0C8BF29D14E2100000015 /* LocationManager.swift */,
+AAB0C8C029D14E2100000016 /* AudioPlayer.swift */,
+);
+path = Managers;
+sourceTree = "<group>";
+};
+AAB0C8B529D14E210000000B /* Models */ = {
+isa = PBXGroup;
+children = (
+AAB0C8BC29D14E2100000012 /* AudioDrop.swift */,
+);
+path = Models;
+sourceTree = "<group>";
+};
+AAB0C8B629D14E210000000C /* ViewModels */ = {
+isa = PBXGroup;
+children = (
+AAB0C8BB29D14E2100000011 /* AudioDropViewModel.swift */,
+);
+path = ViewModels;
+sourceTree = "<group>";
+};
+AAB0C8B729D14E210000000D /* Resources */ = {
+isa = PBXGroup;
+children = (
+AAB0C8C129D14E2100000017 /* Assets.xcassets */,
+);
+path = Resources;
+sourceTree = "<group>";
+};
+AAB0C8B829D14E210000000E /* Preview Content */ = {
+isa = PBXGroup;
+children = (
+AAB0C8C329D14E2100000019 /* Preview Assets.xcassets */,
+);
+path = "Preview Content";
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+AAB0C8AD29D14E2100000003 /* HearHere */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = AAB0C8D229D14E2200000030 /* Build configuration list for PBXNativeTarget "HearHere" */;
+buildPhases = (
+AAB0C8AE29D14E2100000004 /* Sources */,
+AAB0C8AF29D14E2100000005 /* Frameworks */,
+AAB0C8B029D14E2100000006 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = HearHere;
+productName = HearHere;
+productReference = AAB0C8B229D14E2100000008 /* HearHere.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+AAB0C8AB29D14E2100000001 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = YES;
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+ORGANIZATIONNAME = "";
+TargetAttributes = {
+AAB0C8AD29D14E2100000003 = {
+CreatedOnToolsVersion = 15.0;
+DevelopmentTeam = "";
+ProvisioningStyle = Automatic;
+};
+};
+};
+buildConfigurationList = AAB0C8D129D14E220000002E /* Build configuration list for PBXProject "HearHere" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = AAB0C8AC29D14E2100000002;
+productRefGroup = AAB0C8B129D14E2100000007 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+AAB0C8AD29D14E2100000003 /* HearHere */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+AAB0C8B029D14E2100000006 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+AAB0C8D829D14E2100000028 /* Assets.xcassets in Resources */,
+AAB0C8D929D14E2100000029 /* Preview Assets.xcassets in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+AAB0C8AE29D14E2100000004 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+AAB0C8D029D14E2100000020 /* ContentView.swift in Sources */,
+AAB0C8D329D14E2100000023 /* AudioDrop.swift in Sources */,
+AAB0C8D729D14E2100000027 /* AudioPlayer.swift in Sources */,
+AAB0C8D129D14E2100000021 /* HearHereApp.swift in Sources */,
+AAB0C8D429D14E2100000024 /* AudioDropStore.swift in Sources */,
+AAB0C8D229D14E2100000022 /* AudioDropViewModel.swift in Sources */,
+AAB0C8D629D14E2100000026 /* LocationManager.swift in Sources */,
+AAB0C8D529D14E2100000025 /* AudioRecorder.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+AAB0C8D029D14E220000002F /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Debug;
+};
+AAB0C8D129D14E2200000030 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Release;
+};
+AAB0C8D329D14E2200000031 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+ENABLE_PREVIEWS = YES;
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = HearHere/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.HearHere;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Debug;
+};
+AAB0C8D429D14E2200000032 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+ENABLE_PREVIEWS = YES;
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = HearHere/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.HearHere;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+AAB0C8D129D14E220000002E /* Build configuration list for PBXProject "HearHere" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AAB0C8D029D14E220000002F /* Debug */,
+AAB0C8D129D14E2200000030 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+AAB0C8D229D14E2200000030 /* Build configuration list for PBXNativeTarget "HearHere" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AAB0C8D329D14E2200000031 /* Debug */,
+AAB0C8D429D14E2200000032 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = AAB0C8AB29D14E2100000001 /* Project object */;
+}

--- a/HearHere/ContentView.swift
+++ b/HearHere/ContentView.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    @ObservedObject var viewModel: AudioDropViewModel
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            mapView
+                .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                statusBanner
+
+                metadataFields
+
+                recordingControls
+
+                dropList
+            }
+            .padding()
+            .background(
+                Material.ultraThin
+                    .opacity(0.95)
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+            )
+            .padding()
+        }
+        .task {
+            await viewModel.onAppear()
+        }
+        .alert("Permission Needed", isPresented: $viewModel.showLocationPermissionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("HearHere needs access to your location to drop and discover audio clips.")
+        }
+        .alert("Microphone Restricted", isPresented: $viewModel.showMicrophonePermissionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Enable microphone access in Settings to record new audio drops.")
+        }
+    }
+
+    private var mapView: some View {
+        Map(
+            coordinateRegion: Binding(
+                get: { viewModel.mapRegion },
+                set: { viewModel.updateRegion($0) }
+            ),
+            interactionModes: .all,
+            showsUserLocation: true,
+            annotationItems: viewModel.drops
+        ) { drop in
+            MapAnnotation(coordinate: drop.coordinate.clCoordinate) {
+                AudioDropAnnotationView(isSelected: drop.id == viewModel.selectedDrop?.id)
+                    .onTapGesture {
+                        viewModel.select(drop)
+                    }
+            }
+        }
+    }
+
+    private var statusBanner: some View {
+        HStack {
+            Label(viewModel.statusMessage, systemImage: viewModel.statusIconName)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+            if let location = viewModel.currentLocation {
+                Text("Lat: \(location.coordinate.latitude, specifier: "%.3f"), Lng: \(location.coordinate.longitude, specifier: "%.3f")")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var metadataFields: some View {
+        VStack(spacing: 8) {
+            TextField("Your name (optional)", text: $viewModel.displayName)
+                .textFieldStyle(.roundedBorder)
+            TextField("Leave a note for listeners", text: $viewModel.notes)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var recordingControls: some View {
+        VStack(spacing: 8) {
+            if viewModel.isRecording {
+                Label("Recording...", systemImage: "waveform.badge.mic")
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+            }
+            HStack(spacing: 16) {
+                Button(action: viewModel.toggleRecording) {
+                    Label(viewModel.isRecording ? "Stop Recording" : "Drop Audio", systemImage: viewModel.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(viewModel.isRecording ? .red : .blue)
+                .disabled(!viewModel.canRecord)
+
+                Button(action: viewModel.recenterMap) {
+                    Label("Recenter", systemImage: "location.circle.fill")
+                        .font(.subheadline)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    private var dropList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Nearby Drops")
+                    .font(.headline)
+                Spacer()
+                Button(action: viewModel.refreshDrops) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if viewModel.drops.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("No audio drops yet", systemImage: "ear")
+                        .foregroundStyle(.secondary)
+                    Text("Record a clip to leave behind something to hear here.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 16) {
+                        ForEach(viewModel.drops) { drop in
+                            AudioDropCardView(drop: drop, isSelected: drop.id == viewModel.selectedDrop?.id, playAction: {
+                                viewModel.play(drop)
+                            })
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+}
+
+struct AudioDropCardView: View {
+    let drop: AudioDrop
+    let isSelected: Bool
+    let playAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "waveform")
+                Text(drop.owner.isEmpty ? "Someone" : drop.owner)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Spacer()
+                Text(drop.createdAt, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(drop.notes.isEmpty ? "Tap play to listen" : drop.notes)
+                .font(.caption)
+                .lineLimit(2)
+
+            Button(action: playAction) {
+                Label("Listen", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .frame(width: 220)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(isSelected ? Color.blue.opacity(0.15) : Color(.secondarySystemBackground))
+        )
+    }
+}
+
+struct AudioDropAnnotationView: View {
+    let isSelected: Bool
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected ? .blue : .teal)
+                .frame(width: 32, height: 32)
+            Image(systemName: "waveform")
+                .foregroundStyle(.white)
+        }
+        .shadow(radius: 4)
+    }
+}
+
+#Preview {
+    ContentView(viewModel: AudioDropViewModel.preview)
+}

--- a/HearHere/HearHereApp.swift
+++ b/HearHere/HearHereApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct HearHereApp: App {
+    @StateObject private var viewModel = AudioDropViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: viewModel)
+        }
+    }
+}

--- a/HearHere/Info.plist
+++ b/HearHere/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>HearHere uses your location to drop and discover nearby audio clips.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>The microphone is needed to record audio drops for others to hear.</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string></string>
+                    <key>UISceneStoryboardFile</key>
+                    <string></string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/HearHere/Managers/AudioDropStore.swift
+++ b/HearHere/Managers/AudioDropStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+import CoreLocation
+
+@MainActor
+final class AudioDropStore: ObservableObject {
+    @Published private(set) var drops: [AudioDrop] = []
+
+    private let metadataURL: URL
+    private let audioDirectory: URL
+    private let fileManager: FileManager
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let baseDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        self.audioDirectory = baseDirectory.appendingPathComponent("HearHereAudio", isDirectory: true)
+        self.metadataURL = audioDirectory.appendingPathComponent("drops.json")
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        decoder.dateDecodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .iso8601
+        prepareStore()
+    }
+
+    private func prepareStore() {
+        do {
+            if !fileManager.fileExists(atPath: audioDirectory.path) {
+                try fileManager.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+            }
+            try loadDrops()
+        } catch {
+            #if DEBUG
+            print("AudioDropStore failed to prepare: \(error)")
+            #endif
+        }
+    }
+
+    func refresh() {
+        try? loadDrops()
+    }
+
+    private func loadDrops() throws {
+        guard fileManager.fileExists(atPath: metadataURL.path) else {
+            drops = []
+            return
+        }
+        let data = try Data(contentsOf: metadataURL)
+        let decoded = try decoder.decode([AudioDrop].self, from: data)
+        drops = decoded.sorted(by: { $0.createdAt > $1.createdAt })
+    }
+
+    func addDrop(from sourceURL: URL, coordinate: CLLocationCoordinate2D, owner: String, notes: String) throws -> AudioDrop {
+        let identifier = UUID()
+        let filename = identifier.uuidString.appending(".m4a")
+        let destination = audioDirectory.appendingPathComponent(filename)
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.copyItem(at: sourceURL, to: destination)
+
+        let drop = AudioDrop(
+            id: identifier,
+            coordinate: .init(coordinate),
+            audioFilename: filename,
+            owner: owner,
+            createdAt: Date(),
+            notes: notes
+        )
+        drops.insert(drop, at: 0)
+        try persistDrops()
+        return drop
+    }
+
+    func url(for drop: AudioDrop) -> URL {
+        audioDirectory.appendingPathComponent(drop.audioFilename)
+    }
+
+    private func persistDrops() throws {
+        let data = try encoder.encode(drops)
+        try data.write(to: metadataURL, options: .atomic)
+    }
+}

--- a/HearHere/Managers/AudioPlayer.swift
+++ b/HearHere/Managers/AudioPlayer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+final class AudioPlayer: NSObject, ObservableObject {
+    private var player: AVAudioPlayer?
+
+    func play(url: URL) throws {
+        stop()
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .default, options: [.duckOthers])
+        try session.setActive(true)
+
+        player = try AVAudioPlayer(contentsOf: url)
+        player?.delegate = self
+        player?.prepareToPlay()
+        player?.play()
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+
+extension AudioPlayer: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        stop()
+    }
+}

--- a/HearHere/Managers/AudioRecorder.swift
+++ b/HearHere/Managers/AudioRecorder.swift
@@ -1,0 +1,93 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+final class AudioRecorder: NSObject, ObservableObject {
+    @Published private(set) var hasMicrophonePermission: Bool
+
+    private let session = AVAudioSession.sharedInstance()
+    private var recorder: AVAudioRecorder?
+
+    override init() {
+        switch session.recordPermission {
+        case .granted:
+            hasMicrophonePermission = true
+        case .denied, .undetermined:
+            hasMicrophonePermission = false
+        @unknown default:
+            hasMicrophonePermission = false
+        }
+        super.init()
+    }
+
+    func requestPermission() async -> Bool {
+        if session.recordPermission == .granted {
+            hasMicrophonePermission = true
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            session.requestRecordPermission { [weak self] granted in
+                DispatchQueue.main.async {
+                    self?.hasMicrophonePermission = granted
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    func startRecording() throws -> URL {
+        guard hasMicrophonePermission else {
+            throw RecorderError.microphoneAccessDenied
+        }
+
+        try configureSession()
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("m4a")
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+
+        recorder = try AVAudioRecorder(url: url, settings: settings)
+        recorder?.isMeteringEnabled = true
+        recorder?.record()
+        return url
+    }
+
+    func stopRecording() -> URL? {
+        guard let recorder else { return nil }
+        recorder.stop()
+        let url = recorder.url
+        self.recorder = nil
+        return url
+    }
+
+    func cancelRecording() {
+        guard let recorder else { return }
+        recorder.stop()
+        try? FileManager.default.removeItem(at: recorder.url)
+        self.recorder = nil
+    }
+
+    private func configureSession() throws {
+        try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+}
+
+enum RecorderError: Error, LocalizedError {
+    case microphoneAccessDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .microphoneAccessDenied:
+            return "Microphone access has been denied."
+        }
+    }
+}

--- a/HearHere/Managers/LocationManager.swift
+++ b/HearHere/Managers/LocationManager.swift
@@ -1,0 +1,77 @@
+import Foundation
+import CoreLocation
+
+@MainActor
+final class LocationManager: NSObject, ObservableObject {
+    @Published private(set) var authorizationStatus: CLAuthorizationStatus
+    @Published private(set) var location: CLLocation?
+    @Published private(set) var authorizationDenied = false
+
+    private let manager: CLLocationManager
+
+    override init() {
+        self.manager = CLLocationManager()
+        self.authorizationStatus = manager.authorizationStatus
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        manager.distanceFilter = 5
+    }
+
+    func requestAuthorization() {
+        guard CLLocationManager.locationServicesEnabled() else {
+            authorizationDenied = true
+            return
+        }
+
+        switch authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedAlways, .authorizedWhenInUse:
+            authorizationDenied = false
+            manager.startUpdatingLocation()
+        case .restricted, .denied:
+            authorizationDenied = true
+        @unknown default:
+            authorizationDenied = true
+        }
+    }
+
+    func startUpdatingLocation() {
+        manager.startUpdatingLocation()
+    }
+
+    func stopUpdatingLocation() {
+        manager.stopUpdatingLocation()
+    }
+}
+
+extension LocationManager: CLLocationManagerDelegate {
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            authorizationStatus = manager.authorizationStatus
+            switch authorizationStatus {
+            case .authorizedAlways, .authorizedWhenInUse:
+                authorizationDenied = false
+                self.manager.startUpdatingLocation()
+            case .denied, .restricted:
+                authorizationDenied = true
+            default:
+                break
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let latest = locations.last else { return }
+        Task { @MainActor in
+            location = latest
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        #if DEBUG
+        print("Location manager failed with error: \(error)")
+        #endif
+    }
+}

--- a/HearHere/Models/AudioDrop.swift
+++ b/HearHere/Models/AudioDrop.swift
@@ -1,0 +1,50 @@
+import Foundation
+import CoreLocation
+
+struct AudioDrop: Identifiable, Codable {
+    struct Coordinate: Codable, Hashable {
+        var latitude: Double
+        var longitude: Double
+
+        var clCoordinate: CLLocationCoordinate2D {
+            CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        }
+
+        init(latitude: Double, longitude: Double) {
+            self.latitude = latitude
+            self.longitude = longitude
+        }
+
+        init(_ coordinate: CLLocationCoordinate2D) {
+            self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        }
+    }
+
+    var id: UUID
+    var coordinate: Coordinate
+    var audioFilename: String
+    var owner: String
+    var createdAt: Date
+    var notes: String
+}
+
+extension AudioDrop {
+    static let placeholder = AudioDrop(
+        id: UUID(),
+        coordinate: .init(latitude: 37.3349, longitude: -122.00902),
+        audioFilename: "sample.m4a",
+        owner: "Previewer",
+        createdAt: .now,
+        notes: "Sample audio drop"
+    )
+
+    var title: String {
+        owner.isEmpty ? "Someone" : owner
+    }
+
+    func distance(from location: CLLocation?) -> Measurement<UnitLength>? {
+        guard let location else { return nil }
+        let dropLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        return Measurement(value: dropLocation.distance(from: location), unit: .meters)
+    }
+}

--- a/HearHere/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/HearHere/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/HearHere/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/HearHere/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0588",
+          "green" : "0.5569",
+          "blue" : "0.6353",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/HearHere/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/HearHere/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/HearHere/Resources/Assets.xcassets/Contents.json
+++ b/HearHere/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HearHere/ViewModels/AudioDropViewModel.swift
+++ b/HearHere/ViewModels/AudioDropViewModel.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Combine
+import MapKit
+import CoreLocation
+
+@MainActor
+final class AudioDropViewModel: ObservableObject {
+    @Published var mapRegion: MKCoordinateRegion
+    @Published private(set) var drops: [AudioDrop] = []
+    @Published private(set) var selectedDrop: AudioDrop?
+    @Published private(set) var currentLocation: CLLocation?
+    @Published var showLocationPermissionAlert = false
+    @Published var showMicrophonePermissionAlert = false
+    @Published private(set) var statusMessage = "Initializing..."
+    @Published private(set) var statusIconName = "waveform"
+    @Published private(set) var isRecording = false
+    @Published var displayName: String = ""
+    @Published var notes: String = ""
+
+    var canRecord: Bool {
+        !isRecording && microphonePermissionGranted && currentLocation != nil
+    }
+
+    private let locationManager: LocationManager
+    private let dropStore: AudioDropStore
+    private let audioRecorder: AudioRecorder
+    private let audioPlayer: AudioPlayer
+    private var cancellables: Set<AnyCancellable> = []
+    private var microphonePermissionGranted = false
+    private let isPreview: Bool
+
+    init(
+        locationManager: LocationManager = LocationManager(),
+        dropStore: AudioDropStore = AudioDropStore(),
+        audioRecorder: AudioRecorder = AudioRecorder(),
+        audioPlayer: AudioPlayer = AudioPlayer(),
+        isPreview: Bool = false
+    ) {
+        self.locationManager = locationManager
+        self.dropStore = dropStore
+        self.audioRecorder = audioRecorder
+        self.audioPlayer = audioPlayer
+        self.isPreview = isPreview
+        self.mapRegion = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 37.3349, longitude: -122.00902),
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+
+        if !isPreview {
+            setupBindings()
+            refreshDrops()
+        } else {
+            microphonePermissionGranted = true
+        }
+    }
+
+    func onAppear() async {
+        guard !isPreview else { return }
+        locationManager.requestAuthorization()
+        await ensureMicrophonePermission()
+        updateStatusForCurrentState()
+    }
+
+    func refreshDrops() {
+        dropStore.refresh()
+        drops = dropStore.drops
+    }
+
+    func updateRegion(_ region: MKCoordinateRegion) {
+        mapRegion = region
+    }
+
+    func recenterMap() {
+        if let location = currentLocation {
+            mapRegion.center = location.coordinate
+        } else {
+            statusMessage = "Waiting for your location..."
+            statusIconName = "location.magnifyingglass"
+        }
+    }
+
+    func select(_ drop: AudioDrop) {
+        selectedDrop = drop
+    }
+
+    func play(_ drop: AudioDrop) {
+        do {
+            try audioPlayer.play(url: dropStore.url(for: drop))
+            selectedDrop = drop
+            statusMessage = "Playing \(drop.title)'s drop"
+            statusIconName = "play.circle.fill"
+        } catch {
+            statusMessage = "Playback failed"
+            statusIconName = "exclamationmark.triangle"
+        }
+    }
+
+    func toggleRecording() {
+        if isRecording {
+            Task { await finishRecording() }
+        } else {
+            Task { await beginRecording() }
+        }
+    }
+
+    private func beginRecording() async {
+        guard await ensureMicrophonePermission() else {
+            showMicrophonePermissionAlert = true
+            return
+        }
+
+        guard let _ = currentLocation else {
+            statusMessage = "Waiting for your location before recording"
+            statusIconName = "location.magnifyingglass"
+            return
+        }
+
+        do {
+            _ = try audioRecorder.startRecording()
+            isRecording = true
+            statusMessage = "Recording in progress"
+            statusIconName = "waveform.badge.mic"
+        } catch {
+            statusMessage = "Unable to start recording"
+            statusIconName = "exclamationmark.triangle"
+        }
+    }
+
+    private func finishRecording() async {
+        let recordedURL = audioRecorder.stopRecording()
+        isRecording = false
+
+        guard let recordedURL else {
+            statusMessage = "Recording failed"
+            statusIconName = "exclamationmark.triangle"
+            return
+        }
+
+        guard let location = currentLocation else {
+            statusMessage = "Missing location for drop"
+            statusIconName = "location.slash"
+            try? FileManager.default.removeItem(at: recordedURL)
+            return
+        }
+
+        do {
+            let drop = try dropStore.addDrop(
+                from: recordedURL,
+                coordinate: location.coordinate,
+                owner: displayName.trimmingCharacters(in: .whitespacesAndNewlines),
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            selectedDrop = drop
+            drops = dropStore.drops
+            notes = ""
+            statusMessage = "Audio dropped!"
+            statusIconName = "mappin.circle.fill"
+        } catch {
+            statusMessage = "Could not save audio drop"
+            statusIconName = "exclamationmark.triangle"
+        }
+
+        try? FileManager.default.removeItem(at: recordedURL)
+    }
+
+    private func ensureMicrophonePermission() async -> Bool {
+        if microphonePermissionGranted {
+            return true
+        }
+        let granted = await audioRecorder.requestPermission()
+        microphonePermissionGranted = granted
+        if !granted {
+            showMicrophonePermissionAlert = true
+            statusMessage = "Microphone access denied"
+            statusIconName = "mic.slash"
+        }
+        return granted
+    }
+
+    private func setupBindings() {
+        locationManager.$location
+            .sink { [weak self] location in
+                guard let self else { return }
+                self.currentLocation = location
+                if let location {
+                    self.mapRegion.center = location.coordinate
+                    self.statusMessage = "Listening near \(self.locationDescription(for: location))"
+                    self.statusIconName = "location.fill"
+                } else {
+                    self.statusMessage = "Searching for your location"
+                    self.statusIconName = "location.magnifyingglass"
+                }
+            }
+            .store(in: &cancellables)
+
+        locationManager.$authorizationStatus
+            .removeDuplicates()
+            .sink { [weak self] status in
+                self?.handleAuthorizationStatus(status)
+            }
+            .store(in: &cancellables)
+
+        dropStore.$drops
+            .sink { [weak self] drops in
+                self?.drops = drops
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleAuthorizationStatus(_ status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            showLocationPermissionAlert = false
+        case .denied, .restricted:
+            showLocationPermissionAlert = true
+            statusMessage = "Location access denied"
+            statusIconName = "location.slash"
+        case .notDetermined:
+            statusMessage = "Requesting location access"
+            statusIconName = "location"
+        @unknown default:
+            statusMessage = "Location status unknown"
+            statusIconName = "questionmark.circle"
+        }
+    }
+
+    private func updateStatusForCurrentState() {
+        if currentLocation == nil {
+            statusMessage = "Searching for your location"
+            statusIconName = "location.magnifyingglass"
+        } else {
+            statusMessage = "Ready to drop audio"
+            statusIconName = "waveform"
+        }
+    }
+
+    private func locationDescription(for location: CLLocation) -> String {
+        "\(String(format: "%.3f", location.coordinate.latitude)), \(String(format: "%.3f", location.coordinate.longitude))"
+    }
+}
+
+extension AudioDropViewModel {
+    static var preview: AudioDropViewModel {
+        let viewModel = AudioDropViewModel(
+            locationManager: LocationManager(),
+            dropStore: AudioDropStore(),
+            audioRecorder: AudioRecorder(),
+            audioPlayer: AudioPlayer(),
+            isPreview: true
+        )
+        viewModel.drops = [
+            AudioDrop(
+                id: UUID(),
+                coordinate: .init(latitude: 37.3349, longitude: -122.00902),
+                audioFilename: "preview-1.m4a",
+                owner: "Previewer",
+                createdAt: Date(),
+                notes: "Welcome to HearHere"
+            )
+        ]
+        viewModel.currentLocation = CLLocation(latitude: 37.3349, longitude: -122.00902)
+        viewModel.mapRegion.center = CLLocationCoordinate2D(latitude: 37.3349, longitude: -122.00902)
+        viewModel.statusMessage = "Previewing nearby drops"
+        viewModel.statusIconName = "waveform"
+        return viewModel
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # HearHere
+
+HearHere is an iOS application designed for location-based audio sharing. Users can record short clips tied to their current location and discover drops left by themselves or other community members when they visit the same spot.
+
+## Features
+
+- 📍 **Map-first experience** – View your position and nearby audio drops on an interactive map.
+- 🎙️ **Location-aware recording** – Capture a note and attach it to your current GPS coordinates.
+- 🎧 **Instant playback** – Listen to drops by tapping on map annotations or through the carousel of nearby clips.
+- 🔐 **Permission handling** – Gracefully handles location and microphone permissions with user guidance.
+
+## Getting Started
+
+1. Open `HearHere.xcodeproj` in Xcode 15 or newer.
+2. Select the `HearHere` scheme and choose an iOS simulator or a connected device.
+3. Build and run (`⌘R`).
+
+> **Tip:** The app requires location and microphone permissions. In the simulator you can simulate a custom location via **Features → Location**.
+
+## Project Structure
+
+```
+HearHere/
+├─ HearHereApp.swift           // App entry point
+├─ ContentView.swift           // Root SwiftUI view with map and controls
+├─ Models/                     // Domain models (AudioDrop)
+├─ ViewModels/                 // Observable view models powering the UI
+├─ Managers/                   // Location, audio recording, playback, and persistence helpers
+├─ Resources/Assets.xcassets   // Color and icon assets
+└─ Info.plist                  // App configuration & permission strings
+```
+
+## Next Steps
+
+- Connect a real backend or cloud storage for sharing drops between devices.
+- Add authentication so drops can be attributed to specific users.
+- Enhance audio management (duration limits, waveforms, etc.).
+
+## Requirements
+
+- Xcode 15+
+- iOS 16.0+ deployment target (configurable in project settings)
+
+Enjoy leaving sounds for others to discover! 🔊


### PR DESCRIPTION
## Summary
- initialize a SwiftUI-based HearHere app with a map-focused ContentView wired to a shared view model
- add models plus managers for location services, audio recording/playback, and on-device persistence of audio drops
- configure the Xcode project, assets, Info.plist permissions, and README instructions for building in Xcode

## Testing
- not run (Xcode tooling unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68c99d28aab08331b87d8a7dc5e0f459