### PR TITLE
Fix main actor initialization warnings

### DIFF
--- a/HearHere/ViewModels/AudioDropViewModel.swift
+++ b/HearHere/ViewModels/AudioDropViewModel.swift
@@ -30,16 +30,16 @@ final class AudioDropViewModel: ObservableObject {
     private let isPreview: Bool
 
     init(
-        locationManager: LocationManager = LocationManager(),
-        dropStore: AudioDropStore = AudioDropStore(),
-        audioRecorder: AudioRecorder = AudioRecorder(),
-        audioPlayer: AudioPlayer = AudioPlayer(),
+        locationManager: LocationManager? = nil,
+        dropStore: AudioDropStore? = nil,
+        audioRecorder: AudioRecorder? = nil,
+        audioPlayer: AudioPlayer? = nil,
         isPreview: Bool = false
     ) {
-        self.locationManager = locationManager
-        self.dropStore = dropStore
-        self.audioRecorder = audioRecorder
-        self.audioPlayer = audioPlayer
+        self.locationManager = locationManager ?? LocationManager()
+        self.dropStore = dropStore ?? AudioDropStore()
+        self.audioRecorder = audioRecorder ?? AudioRecorder()
+        self.audioPlayer = audioPlayer ?? AudioPlayer()
         self.isPreview = isPreview
         self.mapRegion = MKCoordinateRegion(
             center: CLLocationCoordinate2D(latitude: 37.3349, longitude: -122.00902),
@@ -240,14 +240,9 @@ final class AudioDropViewModel: ObservableObject {
 }
 
 extension AudioDropViewModel {
+    @MainActor
     static var preview: AudioDropViewModel {
-        let viewModel = AudioDropViewModel(
-            locationManager: LocationManager(),
-            dropStore: AudioDropStore(),
-            audioRecorder: AudioRecorder(),
-            audioPlayer: AudioPlayer(),
-            isPreview: true
-        )
+        let viewModel = AudioDropViewModel(isPreview: true)
         viewModel.drops = [
             AudioDrop(
                 id: UUID(),


### PR DESCRIPTION
## Summary
- instantiate `AudioDropViewModel` dependencies on the main actor to avoid actor-isolation initializer warnings
- mark the preview factory as main actor and reuse the streamlined initializer

## Testing
- not run (xcodebuild not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc275cd72c8331ad00b9cdfdbae34a