### PR TITLE
Handle microphone permission result on appear

### DIFF
--- a/HearHere/ViewModels/AudioDropViewModel.swift
+++ b/HearHere/ViewModels/AudioDropViewModel.swift
@@ -57,8 +57,9 @@ final class AudioDropViewModel: ObservableObject {
     func onAppear() async {
         guard !isPreview else { return }
         locationManager.requestAuthorization()
-        await ensureMicrophonePermission()
-        updateStatusForCurrentState()
+        if await ensureMicrophonePermission() {
+            updateStatusForCurrentState()
+        }
     }
 
     func refreshDrops() {


### PR DESCRIPTION
## Summary
- update the onAppear flow to only refresh the status when microphone permission succeeds
- prevent the "result of call is unused" warning by handling the permission result

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc278b5e48833188fe6ab794cca890