### PR TITLE
Mark audio player delegate extension as MainActor

### DIFF
--- a/HearHere/Managers/AudioPlayer.swift
+++ b/HearHere/Managers/AudioPlayer.swift
@@ -24,6 +24,7 @@ final class AudioPlayer: NSObject, ObservableObject {
     }
 }
 
+@MainActor
 extension AudioPlayer: AVAudioPlayerDelegate {
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         stop()


### PR DESCRIPTION
## Summary
- annotate the AudioPlayer delegate extension with @MainActor to keep delegate callbacks on the main actor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc27b3e6a08331b84a7c36b962a6f4