### PR TITLE
Handle microphone permission updates and add missing usage descriptions

### DIFF
--- a/HearHere/Info.plist
+++ b/HearHere/Info.plist
@@ -22,8 +22,14 @@
     <true/>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>HearHere uses your location to drop and discover nearby audio clips.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>HearHere uses your location to drop and discover nearby audio clips.</string>
+    <key>NSLocationDefaultAccuracyReducedAccuracyUsageDescription</key>
+    <string>Reduced accuracy mode still helps you find nearby audio drops while respecting your privacy.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>The microphone is needed to record audio drops for others to hear.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Bluetooth access lets you record and listen to drops using wireless audio devices.</string>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary
- ensure the audio drop view model keeps its microphone permission state in sync with the recorder and centralizes status messaging updates
- only gate recording on an available location while refreshing UI cues when permissions change
- declare the additional location accuracy and bluetooth privacy usage descriptions required at runtime

## Testing
- ⚠️ `xcodebuild -scheme HearHere -project HearHere.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2dea4b488331a001999bc46260fe